### PR TITLE
feat: ad units conversion logic to measurements screen

### DIFF
--- a/screens/MeasurementsScreen.tsx
+++ b/screens/MeasurementsScreen.tsx
@@ -1,8 +1,11 @@
+import { cmToInches, inchesToCm } from "@/utils";
 import { router } from "expo-router";
 import { useAtom } from "jotai";
+import { useState } from "react";
 import {
   KeyboardAvoidingView,
   Platform,
+  Pressable,
   ScrollView,
   Text,
   TextInput,
@@ -27,9 +30,13 @@ const measurementsList = [
 
 const MeasurementsScreen = () => {
   const [measurements, setMeasurements] = useAtom(measurementsAtom);
+  const [unit, setUnit] = useState("cm");
 
   const handleChange = (key: keyof typeof measurements, value: number) => {
-    setMeasurements((prev) => ({ ...prev, [key]: value }));
+    setMeasurements((prev) => ({
+      ...prev,
+      [key]: unit === "cm" ? value : inchesToCm(value),
+    }));
   };
 
   const isFormComplete = Object.values(measurements).every((val) => val !== "");
@@ -48,19 +55,43 @@ const MeasurementsScreen = () => {
         contentContainerStyle={{ paddingBottom: 120 }}
         className="p-4"
       >
-        <Text className="text-2xl font-bold mb-4 text-center">
-          Enter Measurements
-        </Text>
+        <View className="flex flex-row justify-between items-center mb-4">
+          <Text className="text-2xl font-bold mb-4 text-left">
+            Enter Measurements
+          </Text>
+          <View className="flex-row gap-2 bg-gray-100 rounded-md p-2">
+            <Pressable
+              className={`w-10 ${unit === "cm" ? "bg-blue-500" : "bg-gray-200"} rounded-sm`}
+              onPress={() => setUnit("cm")}
+              disabled={unit === "cm"}
+            >
+              <Text className="text-center text-white font-bold">cm</Text>
+            </Pressable>
+            <Pressable
+              className={`w-10 ${unit === "in" ? "bg-blue-500" : "bg-gray-200"} rounded-sm`}
+              onPress={() => setUnit("in")}
+              disabled={unit === "in"}
+            >
+              <Text className="text-center text-white font-bold">in</Text>
+            </Pressable>
+          </View>
+        </View>
 
         {measurementsList.map(({ label, key }) => (
           <View key={key} className="mb-4">
             <Text className="text-base font-medium mb-1">
-              {label} (in inches)
+              {label} (in {unit})
             </Text>
             <TextInput
               className="border border-gray-300 rounded-md px-4 py-2"
               keyboardType="numeric"
-              value={measurements[key as keyof typeof measurements].toString()}
+              value={
+                unit === "cm"
+                  ? measurements[key as keyof typeof measurements].toString()
+                  : cmToInches(
+                      measurements[key as keyof typeof measurements]
+                    ).toString()
+              }
               onChangeText={(text) =>
                 handleChange(key as keyof typeof measurements, Number(text))
               }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,0 +1,13 @@
+// cm to inches converter
+const cmToInches = (cm: number) => {
+  if (!cm) return 0;
+  return Math.round(cm * 0.393701 * 100) / 100;
+};
+
+// inches to cm converter
+const inchesToCm = (inches: number) => {
+  if (!inches) return 0;
+  return Math.round(inches * 2.54 * 100) / 100;
+};
+
+export { cmToInches, inchesToCm };


### PR DESCRIPTION
### TL;DR

Added unit conversion functionality to the Measurements screen, allowing users to input measurements in either centimeters or inches.

### What changed?

- Added a unit toggle between centimeters (cm) and inches (in) in the Measurements screen
- Created utility functions for converting between cm and inches
- Updated the measurement input fields to display values in the selected unit
- Modified the data storage to always save measurements in centimeters regardless of input unit

### How to test?

1. Navigate to the Measurements screen
2. Toggle between cm and in units using the new selector
3. Enter values in either unit and verify they convert correctly when switching
4. Submit the form and confirm the measurements are saved properly

### Why make this change?

This enhancement improves user experience by providing flexibility in measurement input, accommodating users who are more comfortable with either the metric or imperial system. The underlying data remains consistent by storing all measurements in centimeters while allowing for display and input in the user's preferred unit.