### PR TITLE
fix: print pdf issue and add scale for reference

### DIFF
--- a/atoms/measurements.ts
+++ b/atoms/measurements.ts
@@ -6,6 +6,7 @@ export const measurementsAtom = atom<Measurements>({
   waist: 66,
   fullLength: 33,
   shoulder: 17,
+  shoulderBand: 9,
   blouseLength: 14.5,
   armhole: 17,
   sleeveLength: 23.5,

--- a/components/PatternView.tsx
+++ b/components/PatternView.tsx
@@ -1,11 +1,11 @@
 // src/components/BlousePattern.tsx
 
-import { Measurements } from "@/types";
-import React from "react";
-import Svg, { G } from "react-native-svg";
 import * as BasicBlouse from "@/src/basicBlousePattern";
 import * as SareeBlouse from "@/src/sareeBlousePattern";
+import { Measurements } from "@/types";
+import React from "react";
 import { View } from "react-native";
+import Svg, { G, Rect, Text } from "react-native-svg";
 import { PatternPiece } from "./PatternPiece";
 
 interface Props {
@@ -55,20 +55,29 @@ export const PatternView: React.FC<Props> = ({ measurements, blouseStyle }) => {
   console.log("mesurements", measurements);
   return (
     <View className="h-full">
-      <Svg viewBox="-30 0 80 40" width="100%" height="100%">
-        {/* Render the Front Piece */}
-        <G>
-          <PatternPiece data={frontPiece.data} color="lightpink" />
-        </G>
-
+      <Svg viewBox="-30 10 80 40" width="100%" height="100%">
         {/* Render the Back Piece, offset to the side */}
         <G x={35}>
           <PatternPiece data={backPiece.data} color="lightblue" />
         </G>
 
+        {/* Render the Front Piece */}
+        <G x={0}>
+          <PatternPiece data={frontPiece.data} color="lightpink" />
+        </G>
+
         {/* Render the Sleeve Piece, offset to the side */}
         <G x={10} y={55}>
           <PatternPiece data={sleevePiece.data} color="lightgreen" />
+        </G>
+
+        {/* Scale bar: 5 cm (assuming 10 units = 1 cm, so 50 units = 5 cm) */}
+        <G x={-25} y={47}>
+          {/* Adjust position as needed */}
+          <Rect x={0} y={0} width={50} height={1} fill="black" />
+          <Text x={25} y={-2} fontSize={2} textAnchor="middle" fill="black">
+            5 cm
+          </Text>
         </G>
       </Svg>
     </View>

--- a/screens/MeasurementsScreen.tsx
+++ b/screens/MeasurementsScreen.tsx
@@ -19,6 +19,7 @@ const measurementsList = [
   { label: "Waist", key: "waist" },
   { label: "Full Length", key: "fullLength" },
   { label: "Shoulder", key: "shoulder" },
+  { label: "Shoulder Band Width", key: "shoulderBand" },
   { label: "Blouse Length", key: "blouseLength" },
   { label: "Armhole Depth", key: "armhole" },
   { label: "Sleeve Length", key: "sleeveLength" },
@@ -61,14 +62,18 @@ const MeasurementsScreen = () => {
           </Text>
           <View className="flex-row gap-2 bg-gray-100 rounded-md p-2">
             <Pressable
-              className={`w-10 ${unit === "cm" ? "bg-blue-500" : "bg-gray-200"} rounded-sm`}
+              className={`w-10 ${
+                unit === "cm" ? "bg-blue-500" : "bg-gray-200"
+              } rounded-sm`}
               onPress={() => setUnit("cm")}
               disabled={unit === "cm"}
             >
               <Text className="text-center text-white font-bold">cm</Text>
             </Pressable>
             <Pressable
-              className={`w-10 ${unit === "in" ? "bg-blue-500" : "bg-gray-200"} rounded-sm`}
+              className={`w-10 ${
+                unit === "in" ? "bg-blue-500" : "bg-gray-200"
+              } rounded-sm`}
               onPress={() => setUnit("in")}
               disabled={unit === "in"}
             >

--- a/screens/PatternScreen.tsx
+++ b/screens/PatternScreen.tsx
@@ -83,15 +83,16 @@ const PatternScreen = () => {
 
   const handleExportToPDF = async () => {
     try {
-      const imageUri = await captureRef(patternRef, {
+      const imageBase64 = await captureRef(patternRef, {
         format: "png",
         quality: 1,
+        result: "base64", // Use base64 result
       });
 
       const html = `
         <html>
           <body style="margin:0;padding:0;">
-            <img src="${imageUri}" style="width:100%;" />
+            <img src="data:image/png;base64,${imageBase64}" style="width:100%;" />
           </body>
         </html>
       `;

--- a/src/basicBlousePattern.ts
+++ b/src/basicBlousePattern.ts
@@ -2,7 +2,6 @@ import { Measurements, PatternData } from "@/types";
 import { C, L, M, Point, Q } from "@/utils/patternUtils";
 import { PatternPiece } from "./patternPiece";
 
-
 // --- LOGIC FOR THE FRONT BODICE ---
 export class Front extends PatternPiece {
   constructor(measurements: Measurements) {
@@ -11,11 +10,12 @@ export class Front extends PatternPiece {
   }
 
   protected calculateData(): PatternData {
-    const { chest, fullLength, shoulder } = this.measurements;
+    const { chest, fullLength, shoulder, neckFront, shoulderBand } =
+      this.measurements;
 
     const armholeDepth = chest / 8 + 6.5;
-    const neckWidth = chest / 12 + 1;
-    const neckDepth = chest / 10 + 1;
+    const neckWidth = shoulder - shoulderBand + 1;
+    const neckDepth = neckFront + 1;
     const shoulderPlusEase = shoulder + 1;
     const chestWidth = chest / 4;
     const chestWidthPlusEase = chestWidth + 4;
@@ -46,65 +46,67 @@ export class Front extends PatternPiece {
     const armholeCurve = Q(p[9], p[7], p[8], 0.4);
     const sideSeamCurve = Q(p[12], p[9], p[11], 0.1);
 
-    const outlinePath = M(p[3]) + neckCurve + L(p[13]) + waistCurve + sideSeamCurve + armholeCurve + L(p[3]);
+    const outlinePath =
+      M(p[3]) +
+      neckCurve +
+      L(p[13]) +
+      waistCurve +
+      sideSeamCurve +
+      armholeCurve +
+      L(p[3]);
 
     // --- DART PATH GENERATION (Based on Page 86) ---
     const dartPaths: string[] = [];
-    
+
     // Define an approximate apex point for darts to aim for
     const apexPoint = new Point(p[14].x, p[16].y);
 
     // 1. Main Waist Dart at P14 (3cm intake)
     const waistDartTip = new Point(apexPoint.x, apexPoint.y + 2);
     dartPaths.push(
-      M(new Point(p[14].x - 1.5, p[14].y)) + 
-      L(waistDartTip) + 
-      L(new Point(p[14].x + 1.5, p[14].y)) + 
-      M(new Point(waistDartTip.x, p[14].y)) +
-      L(waistDartTip)
-
+      M(new Point(p[14].x - 1.5, p[14].y)) +
+        L(waistDartTip) +
+        L(new Point(p[14].x + 1.5, p[14].y)) +
+        M(new Point(waistDartTip.x, p[14].y)) +
+        L(waistDartTip)
     );
 
     // 2. Side Dart at P15 (1.5cm intake)
     const sideDartTip = new Point(apexPoint.x - 2, apexPoint.y);
     dartPaths.push(
       M(new Point(p[15].x, p[15].y - 0.75)) +
-      L(sideDartTip) + 
-      L(new Point(p[15].x, p[15].y + 0.75)) +
-      M(new Point(p[15].x, sideDartTip.y)) +
-      L(sideDartTip)
+        L(sideDartTip) +
+        L(new Point(p[15].x, p[15].y + 0.75)) +
+        M(new Point(p[15].x, sideDartTip.y)) +
+        L(sideDartTip)
     );
-    
+
     // 3. Armhole Dart at P16 (1cm intake)
     const armholeDartTip = new Point(apexPoint.x + 2, apexPoint.y);
     dartPaths.push(
       M(new Point(p[16].x, p[16].y - 0.5)) +
-      L(armholeDartTip) +
-      L(new Point(p[16].x, p[16].y + 0.5)) +
-      M(new Point(p[16].x, armholeDartTip.y)) +
-      L(armholeDartTip)
+        L(armholeDartTip) +
+        L(new Point(p[16].x, p[16].y + 0.5)) +
+        M(new Point(p[16].x, armholeDartTip.y)) +
+        L(armholeDartTip)
     );
     // 4. Shoulder Dart at P8 (1cm intake)
     // Calculate shoulderDartTip on the line between p[8] and apexPoint using Pythagorean theorem
     const dx = apexPoint.x - p[8].x;
     const dy = apexPoint.y - p[8].y;
-    
-    const shoulderDartTip = new Point(
-      p[8].x + 0.7 * dx,
-      p[8].y + 0.7 * dy
-    );
+
+    const shoulderDartTip = new Point(p[8].x + 0.7 * dx, p[8].y + 0.7 * dy);
     dartPaths.push(
       M(new Point(p[8].x - 0.5, p[8].y)) +
-      L(shoulderDartTip) +
-      L(new Point(p[8].x + 0.5, p[8].y)) +
-      M(new Point(p[8].x, shoulderDartTip.y)) 
+        L(shoulderDartTip) +
+        L(new Point(p[8].x + 0.5, p[8].y)) +
+        M(new Point(p[8].x, shoulderDartTip.y))
     );
 
     const pointsToRemove = [10, 5, 0, 6, 11, 2, 1];
     for (const pointKey of pointsToRemove) {
       delete p[pointKey];
     }
-
 
     return { points: p, outlinePath, dartPaths };
   }
@@ -118,10 +120,12 @@ export class Back extends PatternPiece {
   }
 
   private calculateData(): PatternData {
-    const { chest, fullLength, shoulder } = this.measurements;
+    const { chest, fullLength, shoulder, neckBack, shoulderBand } =
+      this.measurements;
+
     const armholeDepth = chest / 8 + 6.5;
-    const neckWidth = chest / 12 + 1;
-    const neckDepth = 6.5;
+    const neckWidth = shoulder - shoulderBand + 1;
+    const neckDepth = neckBack + 1;
     const shoulderPlusEase = shoulder + 1;
     const chestWidth = chest / 4;
     const chestWidthPlusEase = chestWidth + 4;
@@ -148,13 +152,23 @@ export class Back extends PatternPiece {
       18: new Point(-shoulderPlusEase - 0.5, armholeDepth - 6.5),
     };
 
-
-    const neckCurve = Q(p[3], p[17], new Point(p[3].x * 0.7, p[17].y * 0.7), 0.5);
+    const neckCurve = Q(
+      p[3],
+      p[17],
+      new Point(p[3].x * 0.7, p[17].y * 0.7),
+      0.5
+    );
     const armholeCurve = Q(p[9], p[7], p[18], 0.65);
     const sideSeamCurve = Q(p[11], p[9], p[15], 0.7);
 
-
-    const outlinePath = M(p[3]) + neckCurve + L(p[2]) + L(p[11]) +  sideSeamCurve + armholeCurve + L(p[3]);
+    const outlinePath =
+      M(p[3]) +
+      neckCurve +
+      L(p[2]) +
+      L(p[11]) +
+      sideSeamCurve +
+      armholeCurve +
+      L(p[3]);
 
     // --- DART PATH GENERATION (Based on Page 86) ---
     const dartPaths: string[] = [];
@@ -163,7 +177,6 @@ export class Back extends PatternPiece {
     for (const pointKey of pointsToRemove) {
       delete p[pointKey];
     }
-
 
     return { points: p, outlinePath, dartPaths };
   }
@@ -192,7 +205,10 @@ export class SleevePiece extends PatternPiece {
     p[3] = new Point(armholeDepthLine, sleeveLength + 1);
     p[4] = new Point(armholeDepthLine, chest / 8); // Bicep width point
     p[5] = new Point(2.5, 0.3); // Back curve guide point
-    const line4_5_midpoint = new Point((p[4].x + p[5].x) / 2, (p[4].y + p[5].y) / 2);
+    const line4_5_midpoint = new Point(
+      (p[4].x + p[5].x) / 2,
+      (p[4].y + p[5].y) / 2
+    );
     p[6] = line4_5_midpoint;
     p[7] = new Point(p[6].x, p[6].y - 2); // Back curve shaper
     p[8] = new Point(p[4].x - 5, p[4].y); // Back shoulder notch (8-4 = 5cm)
@@ -204,7 +220,10 @@ export class SleevePiece extends PatternPiece {
     p[-5] = new Point(-p[5].x, p[5].y); // Front curve guide point
     p[-7] = new Point(-p[6].x, p[6].y - 2); // Back curve shaper
     // Point 9 is on the line between 8 and 5. We'll use a mirrored version for the front curve.
-    const line8m_5m_midpoint = new Point((p[-8].x + p[-5].x) / 2, (p[-8].y + p[-5].y) / 2);
+    const line8m_5m_midpoint = new Point(
+      (p[-8].x + p[-5].x) / 2,
+      (p[-8].y + p[-5].y) / 2
+    );
     p[-9] = line8m_5m_midpoint;
     p[-10] = new Point(-p[10].x, p[10].y); // Front hem corner
 
@@ -217,7 +236,6 @@ export class SleevePiece extends PatternPiece {
       Q(p[-5], p[-4], p[-7], 0.5) +
       L(p[-10]) +
       L(p[10]);
-
 
     const pointsToRemove = [1, 3, 6, 7, -8, -9];
     for (const pointKey of pointsToRemove) {

--- a/types/index.ts
+++ b/types/index.ts
@@ -8,6 +8,7 @@ export interface Measurements {
   waist: number;
   fullLength: number;
   shoulder: number;
+  shoulderBand: number;
   blouseLength: number;
   armhole: number;
   sleeveLength: number;


### PR DESCRIPTION
### TL;DR

Added shoulder band width measurement and improved pattern visualization with a scale bar.

### What changed?

- Added a new `shoulderBand` measurement to track shoulder band width
- Improved neck calculations by using actual neck measurements instead of chest-based formulas
- Reordered pattern pieces in the PatternView component for better layering
- Added a 5cm scale bar to the pattern for better size reference
- Updated PDF export to use base64 encoding for more reliable image handling
- Reorganized imports and fixed code formatting

### How to test?

1. Check that the new "Shoulder Band Width" field appears in the measurements screen
2. Verify the scale bar appears at the bottom of the pattern view
3. Test PDF export functionality to ensure patterns are correctly rendered
4. Confirm that pattern pieces are displayed in the correct order with proper layering

### Why make this change?

The shoulder band width is a critical measurement for proper blouse fit. Using actual neck measurements instead of chest-based formulas produces more accurate patterns. The scale bar provides a visual reference for size, helping users understand the actual dimensions of the pattern. Base64 encoding for PDF exports ensures more reliable image handling across different devices.